### PR TITLE
Fix for issue #32 - Make PoseEstimator thread safe .

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -173,3 +173,6 @@ simgui*.json
 
 # Version file
 src/main/java/frc/robot/BuildConstants.java
+
+# ctre_sim
+ctre_sim/


### PR DESCRIPTION
Just switching the updates map from TreeMap to ConcurrentSkipListMap would have prevented the ConcurrentModificationException but that would have still introduced some race conditions. This change ensures that the drive and vision updates are applied atomically.